### PR TITLE
Ooth local user verification and password reset

### DIFF
--- a/packages/ooth-local/src/__snapshots__/index.test.js.snap
+++ b/packages/ooth-local/src/__snapshots__/index.test.js.snap
@@ -10,6 +10,27 @@ Object {
 }
 `;
 
+exports[`ooth-local after registration after login can generate verification token 1`] = `
+Object {
+  "_id": "<obfuscated>",
+  "email": "test@example.com",
+  "verificationToken": "<obfuscated>",
+}
+`;
+
+exports[`ooth-local after registration after login can verify user with token 1`] = `
+Object {
+  "message": "Email verified",
+  "user": Object {
+    "_id": "<obfuscated>",
+    "local": Object {
+      "email": "test@example.com",
+      "verified": true,
+    },
+  },
+}
+`;
+
 exports[`ooth-local after registration after login can set email 1`] = `
 Object {
   "message": "Email updated.",
@@ -55,6 +76,22 @@ Object {
       "email": "test@example.com",
     },
   },
+}
+`;
+
+exports[`ooth-local after registration can login 2`] = `
+Object {
+  "user": Object {
+    "local": Object {
+      "email": "test@example.com",
+    },
+  },
+}
+`;
+
+exports[`ooth-local after registration can reset password 1`] = `
+Object {
+  "message": "Password has been reset.",
 }
 `;
 

--- a/packages/ooth-local/src/index.js
+++ b/packages/ooth-local/src/index.js
@@ -224,7 +224,7 @@ module.exports = function({
                 throw new Error('No email to verify')
             }
 
-            updateUser(req.user._id, {
+            return updateUser(req.user._id, {
                 verificationToken
             }).then(() => {
                 if (onGenerateVerificationToken) {
@@ -328,7 +328,7 @@ module.exports = function({
                 throw new Error('Invalid password.')
             }
 
-            testValue('password', password)
+            testValue('password', newPassword)
 
             return getUserByFields({
                 passwordResetToken: token

--- a/packages/ooth-local/src/index.test.js
+++ b/packages/ooth-local/src/index.test.js
@@ -304,10 +304,9 @@ describe('ooth-local', () => {
                 })
                 //This is a bit messy, probably need a nestedObfuscate
                 const obfuscatedRes = {
-                    message: (res.message ? res.message: null),
+                    message: (res.message ? res.message : null),
                     user: obfuscate(res.user, '_id')
                 }
-                console.log(obfuscatedRes)
                 expect(obfuscatedRes).toMatchSnapshot()
             })
 


### PR DESCRIPTION
1.  Return updateUser promise chain in ooth-local registered method "generate-verification-token".
  Prior to fix, req was getting closed out early.  So registration token generation email was getting sent out, but req was returning error to user.
2.  Ensure that correct password variable was passed to testValue call in registered method "reset-password".
Prior to fix, password resets were not working.

Updated tests are included, but not sure how to handle any versions changes.