### PR TITLE
Add ability to transform user from strategy plugin

### DIFF
--- a/packages/ooth/src/__snapshots__/index.test.js.snap
+++ b/packages/ooth/src/__snapshots__/index.test.js.snap
@@ -17,6 +17,7 @@ Array [
     "registerProfileField": [Function],
     "registerStrategyUniqueField": [Function],
     "registerUniqueField": [Function],
+    "registerUserTransformer": [Function],
     "requireLogged": [Function],
     "requireNotLogged": [Function],
     "requireNotRegistered": [Function],
@@ -87,6 +88,17 @@ Object {
   "_id": "<obfuscated>",
   "test": Object {
     "foo": 1,
+  },
+}
+`;
+
+exports[`ooth connect method plugin can add properties to user 1`] = `
+Object {
+  "user": Object {
+    "_id": "<obfuscated>",
+    "test": Object {
+      "testProp": "foo",
+    },
   },
 }
 `;

--- a/packages/ooth/src/index.test.js
+++ b/packages/ooth/src/index.test.js
@@ -11,7 +11,7 @@ import _ from 'lodash'
 let mongoUrl = 'mongodb://localhost:27017/oothtest'
 let db
 let config
-let app 
+let app
 let server
 let ooth
 let oothMongo
@@ -228,6 +228,28 @@ describe('ooth', () => {
             expect(obfuscate(res, 'user._id')).toMatchSnapshot()
         })
 
+        test('plugin can add properties to user', async () => {
+            ooth.use('test', ({registerUserTransformer, registerProfileField}) => {
+                registerProfileField('testProp', 'testProp')
+                registerUserTransformer(user => {
+                    if (user) {
+                        user.test.testProp = 'foo'
+                    }
+                    return user
+                })
+            })
+            const res = await request({
+                method: 'POST',
+                uri: 'http://localhost:8080/test/login',
+                body: {
+                    foo: 1,
+                    bar: 2,
+                },
+                json: true,
+            })
+            expect(obfuscate(res, 'user._id')).toMatchSnapshot()
+        })
+
         describe('after login', () => {
             let cookies
             let user
@@ -244,7 +266,7 @@ describe('ooth', () => {
                     resolveWithFullResponse: true
                 })
                 cookies = res.headers['set-cookie']
-                user = res.body.user  
+                user = res.body.user
             })
 
             test('can log out', async () => {


### PR DESCRIPTION
This adds a feature to be able to transform a user from a plugin strategy. This is useful in the case that you want to return additional information about the user that is not contained within the `backend` user store.

For instance, in my application I have an existing service that contains a list of teams that the user belongs to. I want to be able to fetch those teams each time the user logs in, and not persist them in the users database.