### PR TITLE
Features/asymetric jwt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -286,10 +286,22 @@ const oothJwt = require("ooth-jwt").default;
 
 oothJwt({
   ooth, // Required
-  sharedSecret: SHARED_SECRET // Required, can be any long random string, needs to be shared with the API
+  sharedSecret: SHARED_SECRET // Can be any long random string, needs to be shared with the API
 });
 ```
 
+You can also use asymetric encryption instead of shared secret:
+
+```js
+oothJwt({
+  ooth, // Required
+  privateKey: fs.readFileSync('path/to/private.key'),
+  publicKey: fs.readFileSync('path/to/public.key'),
+  algorithm: ALGORITHM_TU_USE // Defaults to 'RS256'. Used only if a publicKey / privateKey pair is provided
+});
+```
+
+You must provide either a sharedSecret, or a privateKey/publicKey pair
 ### API
 
 We'll assume the API is another express app. Here too, you need to enable cookie-based session:
@@ -330,7 +342,7 @@ app.use(passport.session())
 passport.serializeUser((userId, done) => done(null, userId))
 passport.deserializeUser((userId, done) => done(null, userId))
 passport.use('jwt', new JwtStrategy({
-    secretOrKey: SHARED_SECRET, // this should be the sharedKey you used in the ooth config
+    secretOrKey: SHARED_SECRET_OR_KEY, // this should either be the sharedKey or the publicKey you used in the ooth config
     jwtFromRequest: ExtractJwt.fromAuthHeaderWithScheme('jwt'),
 }, (payload, next) => {
     if (!payload.user || typeof payload.user !== 'string') {

--- a/packages/ooth-jwt/src/index.ts
+++ b/packages/ooth-jwt/src/index.ts
@@ -59,6 +59,15 @@ export default function({
   publicKey,
   algorithm = 'RS256'
 }: Options): void {
+  if(sharedSecret === undefined && privateKey === undefined) {
+    throw new Error('Either sharedSecret or privateKey/publicKey pair is required');
+  }
+  if(sharedSecret !== undefined && privateKey !== undefined) {
+    throw new Error('Either sharedSecret or privateKey should be provided, not both');
+  }
+  if(privateKey !== undefined && publicKey === undefined) {
+    throw new Error('publicKey is required with privateKey');
+  }
   // Return jwt after successful (primary) auth
   ooth.registerAuthAfterware(async (result: { [key: string]: any }, userId: string | undefined) => {
     if (userId) {


### PR DESCRIPTION
Improve ooth-jwt to allow either symetric encryption with a shared secret (as current), but also asymetric encryption using public/private key pair.

The idea behind this is to allow jwt loging on API without sharing the secret betwenn the auth server and the API server