### PR TITLE
Fix bootstrap error in fresh clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "docs": "doctoc docs",
     "check-clean-repo": "test -z \"$(git status --porcelain)\"",
-    "bootstrap": "rm -rf packages/*/node_modules && rm packages/*/package-lock.json && lerna exec \"npm i\" --concurrency=1",
+    "bootstrap": "rm -rf packages/*/node_modules && rm -f packages/*/package-lock.json && lerna exec \"npm i\" --concurrency=1",
     "build": "lerna run build --concurrency=1",
     "test-build": "lerna exec \"npm run test && npm run build\" --concurrency=1",
     "safe-publish": "npm run check-clean-repo && npm run bootstrap && lerna link && npm run build && npm run test-build && lerna publish"


### PR DESCRIPTION
Error prompt as below:
  rm: packages/*/package-lock.json: No such file or directory

command 'rm' returns error when target not exists, add option '-f' to
avoid error code.