### PR TITLE
ooth-jwt: add token location option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -297,7 +297,8 @@ const oothJwt = require("ooth-jwt").default;
 
 oothJwt({
   ooth, // Required
-  sharedSecret: SHARED_SECRET // Can be any long random string, needs to be shared with the API
+  sharedSecret: SHARED_SECRET // Can be any long random string, needs to be shared with the API,
+  tokenLocation: 'header' // Place to read token from. Can be 'body', 'header' or 'both'. Defaults to 'both'
 });
 ```
 
@@ -308,7 +309,8 @@ oothJwt({
   ooth, // Required
   privateKey: fs.readFileSync("path/to/private.key"),
   publicKey: fs.readFileSync("path/to/public.key"),
-  algorithm: ALGORITHM_TU_USE // Defaults to 'RS256'. Used only if a publicKey / privateKey pair is provided
+  algorithm: ALGORITHM_TO_USE, // Defaults to 'RS256'. Used only if a publicKey / privateKey pair is provided
+  tokenLocation: 'header'
 });
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -316,6 +316,14 @@ oothJwt({
 
 You must provide either a sharedSecret, or a privateKey/publicKey pair
 
+#### tokenLocation
+
+The 'tokenLocation' option is used to specify where (in the request) to read the token from. 'body' means read from the request body ('token' parameter), 'header' means read from the request Authorization header; and 'both' enables both methods.
+
+The encouraged option is 'header', as standard JWT implementation is to use the Authorization header for the token.
+
+Also, if you use 'ooth-jwt' together with 'ooth-local', 'body' or 'both' will conflict with 'reset-password' and 'verify-email' methods.
+
 ### API
 
 We'll assume the API is another express app. Here too, you need to enable cookie-based session:

--- a/examples/standalone/ooth/index.js
+++ b/examples/standalone/ooth/index.js
@@ -49,7 +49,7 @@ async function start() {
       })
     } 
     oothUser({ ooth });
-    oothJwt({ ooth, sharedSecret: process.env.SHARED_SECRET });
+    oothJwt({ ooth, sharedSecret: process.env.SHARED_SECRET, tokenLocation: 'header' });
     oothWs({ ooth });
 
     app.listen(process.env.PORT, function() {

--- a/packages/ooth-jwt/test/index.test.ts
+++ b/packages/ooth-jwt/test/index.test.ts
@@ -52,6 +52,7 @@ describe('ooth-user', () => {
     oothJwt({
       ooth,
       sharedSecret: 'secret',
+      tokenLocation: 'header'
     });
     ooth.registerProfileFields('foo', 'a');
     ooth.registerPrimaryConnect('foo', 'bar', [], new Strategy((_req: any, done: any) => done(null, { a: 'b' })));


### PR DESCRIPTION
Add a tokenLocation option in ooth-jwt to specify where to read token from. 
Option can be 'header', 'body' or 'both'. Default to 'both', which is the current behavior.

Suggested value is 'header', as using 'both' or 'body' conflict with some ooth-local methods